### PR TITLE
Fix readme link

### DIFF
--- a/src/nxdoc/client-sdks/java-client.md
+++ b/src/nxdoc/client-sdks/java-client.md
@@ -74,4 +74,4 @@ history:
         version: '1'
 
 ---
-{{{md (file_content url='https://raw.githubusercontent.com/nuxeo/nuxeo-java-client/master/README.md')}}}
+[README](https://github.com/nuxeo/nuxeo-java-client/blob/master/README.md)


### PR DESCRIPTION
Github markup doesn't support file_content
see : 
https://stackoverflow.com/questions/35080160/github-include-md-files-in-readme-md
https://github.com/github/markup/issues/1159
https://github.com/github/markup/issues/346
https://github.com/github/markup/issues/172